### PR TITLE
[tayga] EAM patches break CLAT, ignore them for now. JB#60308

### DIFF
--- a/rpm/tayga.spec
+++ b/rpm/tayga.spec
@@ -11,10 +11,10 @@ Patch3:     0003-cflags-override.patch
 Patch4:     0004-quote-make-var.patch
 Patch5:     0005-guard-chdir.patch
 Patch6:     0006-guard-write.patch
-Patch7:     0007-static-EAM.patch
+#Patch7:     0007-static-EAM.patch
 Patch8:     0008-manpage-RFC.patch
 Patch9:     0009-include-for-writev.patch
-Patch10:    0010-null-char.patch
+#Patch10:    0010-null-char.patch
 
 BuildRoot:    %{_tmppath}/%{name}-%{version}-build
 Requires:    iproute


### PR DESCRIPTION
The EAM patches extend the configuration to support networks. This breaks the first prototype of CLAT implementation. The patches are set to be ignored for the time being until the issue is investigated.